### PR TITLE
Switch from helm to ivy & counsel

### DIFF
--- a/emacs.org
+++ b/emacs.org
@@ -1553,7 +1553,9 @@ counsel-keys
 | C-x C-f | counsel-find-file         |                       |                  |       |
 | C-x b   | counsel-switch-buffer     |                       |                  |       |
 | M-s o   | swiper-thing-at-point     |                       |                  |       |
+| M-s g   | counsel-grep              |                       |                  |       |
 | M-s s   | counsel-ag                |                       |                  |       |
+| M-s r   | counsel-rg                |                       |                  |       |
 | M-y     | counsel-yank-pop          |                       |                  |       |
 | C-M-? b | counsel-descbinds         |                       |                  |       |
 | C-M-? f | counsel-describe-function |                       |                  |       |

--- a/emacs.org
+++ b/emacs.org
@@ -1560,6 +1560,7 @@ counsel-keys
 | C-x b   | counsel-switch-buffer     |                       |                  |       |
 | C-x C-r | ivy-resume                |                       |                  |       |
 | C-s     | swiper-isearch            |                       |                  |       |
+| C-r     | swiper-isearch-backward   |                       |                  |       |
 | M-s o   | swiper-thing-at-point     |                       |                  |       |
 | M-s g   | counsel-grep              |                       |                  |       |
 | M-s s   | counsel-ag                |                       |                  |       |
@@ -1622,6 +1623,10 @@ counsel-keys
    ("scs" counsel-projectile-switch-project--jw-sbt-action "sbt")
    ("scc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
 #+END_SRC
+
+#+RESULTS:
+| ivy-switch-buffer | ((f ivy--find-file-action find file) (j ivy--switch-buffer-other-window-action other window) (k ivy--kill-buffer-action kill) (r ivy--rename-buffer-action rename) (x counsel-open-buffer-file-externally open externally)) | t | ((i ivy--action-insert insert) (w ivy--action-copy copy)) | swiper-isearch | ((w swiper-action-copy copy)) | swiper | ((w swiper-action-copy copy)) | counsel-describe-variable | ((I counsel-info-lookup-symbol info) (d counsel--find-symbol definition)) | counsel-describe-function | ((I counsel-info-lookup-symbol info) (d counsel--find-symbol definition)) | counsel-describe-symbol | ((I counsel-info-lookup-symbol info) (d counsel--find-symbol definition)) | counsel-M-x | ((d counsel--find-symbol definition) (h #[257 \301!!\207 [counsel-describe-function-function intern] 4 |
+
 
 * private
 

--- a/emacs.org
+++ b/emacs.org
@@ -915,7 +915,6 @@ base-keys (keys not in other parts of this config)
 | C-x 3         | split-window-right-last-buffer-or-scratch |                |      |                           |
 | M-;           | comment-dwim-dwim                         |                |      |                           |
 | C-M-\         | indent-region-or-buffer                   |                |      |                           |
-| M-/           | dabbrev-expand                            |                |      | helm-dabbrev doesn't work |
 | M-g           | magit-status                              |                |      |                           |
 | C-=           | er/expand-region                          |                |      |                           |
 | C-+           | er/contract-region                        |                |      |                           |

--- a/emacs.org
+++ b/emacs.org
@@ -1565,7 +1565,7 @@ counsel-keys
 | M-s g   | counsel-grep              |                       |                  |       |
 | M-s s   | counsel-ag                |                       |                  |       |
 | M-s r   | counsel-rg                |                       |                  |       |
-| M-y     | counsel-yank-pop          |                       |                  |       |
+| C-M-y   | counsel-yank-pop          |                       |                  |       |
 | C-M-? b | counsel-descbinds         |                       |                  |       |
 | C-M-? f | counsel-describe-function |                       |                  |       |
 | C-M-? v | counsel-describe-variable |                       |                  |       |

--- a/emacs.org
+++ b/emacs.org
@@ -1572,7 +1572,6 @@ counsel-keys
 | C-M-? l | counsel-find-library      |                       |                  |       |
 | M-p     | counsel-esh-history       | eshell-mode-map       | eshell-mode-hook |       |
 | C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
-| C-c p   | projectile-command-map    |                       |                  |       |
 
 #+HEADER: :var counsel-keys=counsel-keys
 #+BEGIN_SRC emacs-lisp
@@ -1580,11 +1579,7 @@ counsel-keys
 
 (setq ivy-use-virtual-buffers t)
 (setq ivy-count-format "%d/%d ")
-(setq projectile-completion-system 'ivy)
-
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
-
-(counsel-projectile-mode)
 
 (keybinding-org-table 'counsel-keys)
 
@@ -1607,6 +1602,22 @@ counsel-keys
    ("sr" counsel-find-file--counsel-rg-action "rg in pwd")
    ("scs" counsel-find-file--jw-sbt-action "sbt in pwd")
    ("scc" counsel-find-file--sbt-compile-action "sbt compile in pwd")))
+#+END_SRC
+
+** projectile
+
+projectile-keys
+#+NAME: projectile-keys
+| Key   | Function               |
+|-------+------------------------|
+| C-c p | projectile-command-map |
+
+#+HEADER: :var projectile-keys=projectile-keys
+#+BEGIN_SRC emacs-lisp
+(setq projectile-completion-system 'ivy)
+(counsel-projectile-mode)
+
+(keybinding-org-table 'projectile-keys)
 
 (defun counsel-projectile-switch-project--jw-sbt-action (project)
   (let ((projectile-switch-project-action 'jw-sbt))
@@ -1621,6 +1632,16 @@ counsel-keys
  '(("g" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky") ;; counsel-projectile defaults magit to v, but I like g
    ("scs" counsel-projectile-switch-project--jw-sbt-action "sbt")
    ("scc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
+
+(defalias 'projectile-empty-garbage 'projectile-cleanup-known-projects)
+(defalias 'projectile-purge-everything 'projectile-clear-known-projects)
+
+(defun projectile-clear-known-projects--advice--ask-y-or-n (original-function)
+  (if (yes-or-no-p "This will REMOVE ALL projects from projectile. Are you sure?")
+      (apply original-function)
+    (message "Did NOT clear the projectile projects.")))
+
+(advice-add 'projectile-clear-known-projects :around 'projectile-clear-known-projects--advice--ask-y-or-n)
 #+END_SRC
 
 * private

--- a/emacs.org
+++ b/emacs.org
@@ -1580,6 +1580,7 @@ counsel-keys
 
 (setq ivy-use-virtual-buffers t)
 (setq ivy-count-format "%d/%d ")
+(setq projectile-completion-system 'ivy)
 
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
 

--- a/emacs.org
+++ b/emacs.org
@@ -886,58 +886,60 @@ If the prefix arg is 4, then kill the comment on the current line."
 
 base-keys (keys not in other parts of this config)
 #+NAME: base-keys
-| Key           | Function                                  | Scope       | Hook | Notes                     |
-|---------------+-------------------------------------------+-------------+------+---------------------------|
-| C-z           | nil                                       |             |      | remove suspend            |
-| C-x C-z       | nil                                       |             |      |                           |
-| C-x C-c       | life-might-be-too-much                    |             |      |                           |
-| C-h           | nil                                       |             |      | remove original help      |
-| C-M-?         | help-command                              |             |      |                           |
-| C-M-? p       | delete-process-i                          |             |      |                           |
-| <return>      | toggle-frame-maximized                    | ctl-x-5-map |      |                           |
-| S-<return>    | toggle-frame-fullscreen                   | ctl-x-5-map |      |                           |
-| M-!           | cmd-dwim                                  |             |      |                           |
-| M-&           | cmd-dwim                                  |             |      |                           |
-| C-s           | isearch-forward-regexp                    |             |      |                           |
-| C-r           | isearch-backward-regexp                   |             |      |                           |
-| C-M-g         | goto-line                                 |             |      |                           |
-| C-M-9         | winner-undo                               |             |      |                           |
-| C-M-0         | winner-redo                               |             |      |                           |
-| t             | transpose-windows                         | ctl-x-4-map |      |                           |
-| s             | toggle-window-split                       | ctl-x-4-map |      |                           |
-| C-w           | kill-region-or-line                       |             |      |                           |
-| M-w           | kill-ring-save-region-or-line             |             |      |                           |
-| C-a           | beginning-of-line-or-indentation          |             |      |                           |
-| C-o           | open-line-previous                        |             |      |                           |
-| C-<return>    | open-line-next                            |             |      |                           |
-| C-j           | newline-and-open-line-previous            |             |      |                           |
-| C-x 2         | split-window-down-last-buffer-or-scratch  |             |      |                           |
-| C-x 3         | split-window-right-last-buffer-or-scratch |             |      |                           |
-| M-;           | comment-dwim-dwim                         |             |      |                           |
-| C-M-\         | indent-region-or-buffer                   |             |      |                           |
-| M-/           | dabbrev-expand                            |             |      | helm-dabbrev doesn't work |
-| M-g           | magit-status                              |             |      |                           |
-| C-=           | er/expand-region                          |             |      |                           |
-| C-+           | er/contract-region                        |             |      |                           |
-| C-?           | mc/mark-all-like-this                     |             |      |                           |
-| C-<           | mc/mark-previous-like-this                |             |      |                           |
-| C->           | mc/mark-next-like-this                    |             |      |                           |
-| C-x r t       | mc/edit-lines                             |             |      |                           |
-| M-s j         | dumb-jump-go                              |             |      |                           |
-| M-s J         | dumb-jump-go-other-window                 |             |      |                           |
-| M-<backspace> | nil                                       | sp-keymap   |      |                           |
-| C-M-p         | nil                                       | sp-keymap   |      |                           |
-| C-M-n         | nil                                       | sp-keymap   |      |                           |
-| C-x m         | jw-keymap                                 |             |      |                           |
-| C-c m         | jw-keymap                                 |             |      |                           |
-| m             | jw-keymap                                 | ctl-x-4-map |      |                           |
-| m             | jw-keymap                                 | ctl-x-5-map |      |                           |
-| !             | cmd-menu                                  | jw-keymap   |      |                           |
-| &             | cmd-menu                                  | jw-keymap   |      |                           |
-| q             | emacs-configs-toggle                      | jw-keymap   |      |                           |
-| d             | date                                      | jw-keymap   |      |                           |
-| i             | toggle-scratch-buffer                     | jw-keymap   |      |                           |
-| I             | tmp-scratch-buffer                        | jw-keymap   |      |                           |
+| Key           | Function                                  | Scope          | Hook | Notes                     |
+|---------------+-------------------------------------------+----------------+------+---------------------------|
+| C-z           | nil                                       |                |      | remove suspend            |
+| C-x C-z       | nil                                       |                |      |                           |
+| C-x C-c       | life-might-be-too-much                    |                |      |                           |
+| C-h           | nil                                       |                |      | remove original help      |
+| C-M-?         | help-command                              |                |      |                           |
+| C-M-? p       | delete-process-i                          |                |      |                           |
+| <return>      | toggle-frame-maximized                    | ctl-x-5-map    |      |                           |
+| S-<return>    | toggle-frame-fullscreen                   | ctl-x-5-map    |      |                           |
+| M-!           | cmd-dwim                                  |                |      |                           |
+| M-&           | cmd-dwim                                  |                |      |                           |
+| C-s           | isearch-forward-regexp                    |                |      |                           |
+| C-r           | isearch-backward-regexp                   |                |      |                           |
+| C-M-g         | goto-line                                 |                |      |                           |
+| C-M-9         | winner-undo                               |                |      |                           |
+| C-M-0         | winner-redo                               |                |      |                           |
+| t             | transpose-windows                         | ctl-x-4-map    |      |                           |
+| s             | toggle-window-split                       | ctl-x-4-map    |      |                           |
+| C-w           | kill-region-or-line                       |                |      |                           |
+| M-w           | kill-ring-save-region-or-line             |                |      |                           |
+| C-a           | beginning-of-line-or-indentation          |                |      |                           |
+| C-o           | open-line-previous                        |                |      |                           |
+| C-<return>    | open-line-next                            |                |      |                           |
+| C-j           | newline-and-open-line-previous            |                |      |                           |
+| C-x 2         | split-window-down-last-buffer-or-scratch  |                |      |                           |
+| C-x 3         | split-window-right-last-buffer-or-scratch |                |      |                           |
+| M-;           | comment-dwim-dwim                         |                |      |                           |
+| C-M-\         | indent-region-or-buffer                   |                |      |                           |
+| M-/           | dabbrev-expand                            |                |      | helm-dabbrev doesn't work |
+| M-g           | magit-status                              |                |      |                           |
+| C-=           | er/expand-region                          |                |      |                           |
+| C-+           | er/contract-region                        |                |      |                           |
+| C-?           | mc/mark-all-like-this                     |                |      |                           |
+| C-<           | mc/mark-previous-like-this                |                |      |                           |
+| C->           | mc/mark-next-like-this                    |                |      |                           |
+| C-x r t       | mc/edit-lines                             |                |      |                           |
+| M-s j         | dumb-jump-go                              |                |      |                           |
+| M-s J         | dumb-jump-go-other-window                 |                |      |                           |
+| M-<backspace> | nil                                       | sp-keymap      |      |                           |
+| C-M-p         | nil                                       | sp-keymap      |      |                           |
+| C-M-n         | nil                                       | sp-keymap      |      |                           |
+| C-x m         | jw-keymap                                 |                |      |                           |
+| C-c m         | jw-keymap                                 |                |      |                           |
+| m             | jw-keymap                                 | ctl-x-4-map    |      |                           |
+| m             | jw-keymap                                 | ctl-x-5-map    |      |                           |
+| !             | cmd-menu                                  | jw-keymap      |      |                           |
+| &             | cmd-menu                                  | jw-keymap      |      |                           |
+| q             | emacs-configs-toggle                      | jw-keymap      |      |                           |
+| d             | date                                      | jw-keymap      |      |                           |
+| i             | toggle-scratch-buffer                     | jw-keymap      |      |                           |
+| I             | tmp-scratch-buffer                        | jw-keymap      |      |                           |
+| C-x C-q       | wdired-change-to-wdired-mode              | dired-mode-map |      |                           |
+| w             | wdired-change-to-wdired-mode              | dired-mode-map |      |                           |
 
 #+HEADER: :var base-keys=base-keys
 #+BEGIN_SRC emacs-lisp

--- a/emacs.org
+++ b/emacs.org
@@ -1556,7 +1556,10 @@ counsel-keys
 |---------+---------------------------+-----------------------+------------------+-------|
 | M-x     | counsel-M-x               |                       |                  |       |
 | C-x C-f | counsel-find-file         |                       |                  |       |
+| C-x F   | counsel-file-jump         |                       |                  |       |
 | C-x b   | counsel-switch-buffer     |                       |                  |       |
+| C-x C-r | ivy-resume                |                       |                  |       |
+| C-s     | swiper-thing-at-point     |                       |                  |       |
 | M-s o   | swiper-thing-at-point     |                       |                  |       |
 | M-s g   | counsel-grep              |                       |                  |       |
 | M-s s   | counsel-ag                |                       |                  |       |
@@ -1569,6 +1572,7 @@ counsel-keys
 | M-p     | counsel-esh-history       | eshell-mode-map       | eshell-mode-hook |       |
 | C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
 | C-c p   | projectile-command-map    |                       |                  |       |
+| C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
 
 #+HEADER: :var counsel-keys=counsel-keys
 #+BEGIN_SRC emacs-lisp

--- a/emacs.org
+++ b/emacs.org
@@ -695,13 +695,12 @@ Interactively:
           (t (message (string-trim (shell-command-to-string prepared-cmd)))))
       (cmd prepared-cmd))))
 
-;; todojoe do i need this?
-;; (jw--define-menu cmd-menu 'cmd-menu
-;;   :actions '("Command menu (C-c m !)"
-;;              (?! "sh cmd async    M-! (C-u echo area / C-u C-u at point)" cmd-dwim)
-;;              (?: "elisp evaluate  M-:" helm-eval-expression-with-eldoc)
-;;              (?* "calc evaluate   M-*" helm-calcul-expression))
-;;   :max-action-columns 1)
+(jw--define-menu cmd-menu 'cmd-menu
+  :actions '("Command menu (C-c m !)"
+             (?! "sh cmd async    M-! (C-u echo area / C-u C-u at point)" cmd-dwim)
+             (?: "elisp evaluate  M-:" eval-expression)
+             (?* "calculator   M-*" calculator))
+  :max-action-columns 1)
 
 (defun transpose-windows (arg)
   (interactive "p")
@@ -1589,9 +1588,6 @@ counsel-keys
  '(("g" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky") ;; counsel-projectile defaults magit to v, but I like g
    ("js" counsel-projectile-switch-project--jw-sbt-action "sbt")
    ("jc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
-
-;; todojoe -- wgrep'ing
-;; todojoe -- how to show more key hints from hydra in M-o?
 #+END_SRC
 
 * private

--- a/emacs.org
+++ b/emacs.org
@@ -1588,9 +1588,10 @@ counsel-keys
 
 (keybinding-org-table 'counsel-keys)
 
-(defun counsel-find-file--cmd-dwim-action (file) (let ((default-directory ivy--directory)) (call-interactively 'cmd-dwim)))
+(defun counsel-find-file--cmd-dwim-action (file) (let ((default-directory ivy--directory)) (cmd-dwim ivy-current-prefix-arg)))
 (defun counsel-find-file--magit-status-action (file) (let ((default-directory ivy--directory)) (magit-status)))
 (defun counsel-find-file--eshell-action (file) (let ((default-directory ivy--directory)) (eshell)))
+(defun counsel-find-file--dired-action (file) (dired ivy--directory))
 (defun counsel-find-file--counsel-ag-action (file) (counsel-ag nil ivy--directory))
 (defun counsel-find-file--counsel-rg-action (file) (counsel-rg nil ivy--directory))
 (defun counsel-find-file--jw-sbt-action (file) (let ((default-directory ivy--directory)) (jw-sbt)))
@@ -1599,6 +1600,7 @@ counsel-keys
 (ivy-add-actions
  'counsel-find-file
  '(("!" counsel-find-file--cmd-dwim-action "cmd-dwim in pwd")
+   ("D" counsel-find-file--dired-action "dired in pwd")
    ("g" counsel-find-file--magit-status-action "magit-status in pwd")
    ("xe" counsel-find-file--eshell-action "eshell in pwd")
    ("ss" counsel-find-file--counsel-ag-action "ag in pwd")

--- a/emacs.org
+++ b/emacs.org
@@ -1557,7 +1557,6 @@ counsel-keys
 | M-s s   | counsel-ag                |                       |                  |       |
 | M-s r   | counsel-rg                |                       |                  |       |
 | M-y     | counsel-yank-pop          |                       |                  |       |
-| !       | ivy-dispatching-done      | ivy-minibuffer-map    |                  |       |
 | C-M-? b | counsel-descbinds         |                       |                  |       |
 | C-M-? f | counsel-describe-function |                       |                  |       |
 | C-M-? v | counsel-describe-variable |                       |                  |       |
@@ -1573,6 +1572,11 @@ counsel-keys
 (setq ivy-use-virtual-buffers t)
 (setq ivy-count-format "")
 ;; (setq ivy-use-selectable-prompt t) ;; todojoe -- what does this do?
+
+;; ivy-read-action-function can be switched so that actions are selected by cursor
+;; but then they can no longer be selected by key...
+
+(setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
 
 (counsel-projectile-mode)
 

--- a/emacs.org
+++ b/emacs.org
@@ -832,6 +832,10 @@ If the prefix arg is 4, then kill the comment on the current line."
 (defun display-current-prefix-arg (arg)
   (interactive "P")
   (message "%s" arg))
+
+(defun delete-process-i(p)
+  (interactive `(,(completing-read "Kill process: " (mapcar 'process-name (process-list)) () t)))
+  (delete-process p))
 #+END_SRC
 
 *** emacs
@@ -889,7 +893,7 @@ base-keys (keys not in other parts of this config)
 | C-x C-c       | life-might-be-too-much                    |             |      |                           |
 | C-h           | nil                                       |             |      | remove original help      |
 | C-M-?         | help-command                              |             |      |                           |
-| C-M-? p       | list-processes                            |             |      |                           |
+| C-M-? p       | delete-process-i                          |             |      |                           |
 | <return>      | toggle-frame-maximized                    | ctl-x-5-map |      |                           |
 | S-<return>    | toggle-frame-fullscreen                   | ctl-x-5-map |      |                           |
 | M-!           | cmd-dwim                                  |             |      |                           |

--- a/emacs.org
+++ b/emacs.org
@@ -1559,7 +1559,7 @@ counsel-keys
 | C-x F   | counsel-file-jump         |                       |                  |       |
 | C-x b   | counsel-switch-buffer     |                       |                  |       |
 | C-x C-r | ivy-resume                |                       |                  |       |
-| C-s     | swiper-thing-at-point     |                       |                  |       |
+| C-s     | swiper-isearch            |                       |                  |       |
 | M-s o   | swiper-thing-at-point     |                       |                  |       |
 | M-s g   | counsel-grep              |                       |                  |       |
 | M-s s   | counsel-ag                |                       |                  |       |

--- a/emacs.org
+++ b/emacs.org
@@ -1581,6 +1581,13 @@ counsel-keys
 (setq ivy-count-format "%d/%d ")
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
 
+(require 'cl)
+(defun ivy-remove-action (cmd key)
+  (setq ivy--actions-list
+        (plist-put ivy--actions-list cmd
+                   (cl-remove-if (lambda (action) (equal key (car action)))
+                                 (plist-get ivy--actions-list cmd)))))
+
 (defun ivy-dispatching-done-ivy ()
   (interactive)
   (let ((ivy-read-action-function #'ivy-read-action-ivy))
@@ -1596,6 +1603,8 @@ counsel-keys
 (defun counsel-find-file--counsel-rg-action (file) (counsel-rg nil ivy--directory))
 (defun counsel-find-file--jw-sbt-action (file) (let ((default-directory ivy--directory)) (jw-sbt)))
 (defun counsel-find-file--sbt-compile-action (file) (let ((default-directory ivy--directory)) (sbt-compile ivy-current-prefix-arg)))
+
+(ivy-remove-action 'counsel-find-file "x")
 
 (ivy-add-actions
  'counsel-find-file

--- a/emacs.org
+++ b/emacs.org
@@ -1575,7 +1575,7 @@ counsel-keys
 (ivy-mode 1)
 
 (setq ivy-use-virtual-buffers t)
-(setq ivy-count-format "")
+(setq ivy-count-format "%d/%d ")
 ;; (setq ivy-use-selectable-prompt t) ;; todojoe -- what does this do?
 
 ;; ivy-read-action-function can be switched so that actions are selected by cursor

--- a/emacs.org
+++ b/emacs.org
@@ -1561,8 +1561,6 @@ counsel-keys
 | C-x F   | counsel-file-jump         |                       |                  |       |
 | C-x b   | counsel-switch-buffer     |                       |                  |       |
 | C-x C-r | ivy-resume                |                       |                  |       |
-| C-s     | swiper-isearch            |                       |                  |       |
-| C-r     | swiper-isearch-backward   |                       |                  |       |
 | M-s o   | swiper-thing-at-point     |                       |                  |       |
 | M-s g   | counsel-grep              |                       |                  |       |
 | M-s s   | counsel-ag                |                       |                  |       |

--- a/emacs.org
+++ b/emacs.org
@@ -1573,7 +1573,6 @@ counsel-keys
 | M-p     | counsel-esh-history       | eshell-mode-map       | eshell-mode-hook |       |
 | C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
 | C-c p   | projectile-command-map    |                       |                  |       |
-| C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
 
 #+HEADER: :var counsel-keys=counsel-keys
 #+BEGIN_SRC emacs-lisp

--- a/emacs.org
+++ b/emacs.org
@@ -1557,6 +1557,7 @@ counsel-keys
 | M-s s   | counsel-ag                |                       |                  |       |
 | M-s r   | counsel-rg                |                       |                  |       |
 | M-y     | counsel-yank-pop          |                       |                  |       |
+| !       | ivy-dispatching-done      | ivy-minibuffer-map    |                  |       |
 | C-M-? b | counsel-descbinds         |                       |                  |       |
 | C-M-? f | counsel-describe-function |                       |                  |       |
 | C-M-? v | counsel-describe-variable |                       |                  |       |

--- a/emacs.org
+++ b/emacs.org
@@ -1579,6 +1579,7 @@ counsel-keys
 
 (setq ivy-use-virtual-buffers t)
 (setq ivy-count-format "%d/%d ")
+(setq ivy-initial-inputs-alist nil)
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
 
 (require 'cl)

--- a/emacs.org
+++ b/emacs.org
@@ -1587,6 +1587,20 @@ counsel-keys
 
 (keybinding-org-table 'counsel-keys)
 
+(defun counsel-find-file--cmd-dwim-action (file) (let ((default-directory ivy--directory)) (call-interactively 'cmd-dwim)))
+(defun counsel-find-file--magit-status-action (file) (let ((default-directory ivy--directory)) (magit-status)))
+(defun counsel-find-file--eshell-action (file) (let ((default-directory ivy--directory)) (eshell)))
+(defun counsel-find-file--counsel-ag-action (file) (counsel-ag nil ivy--directory))
+(defun counsel-find-file--counsel-rg-action (file) (counsel-rg nil ivy--directory))
+
+(ivy-set-actions
+ 'counsel-find-file
+ '(("!" counsel-find-file--cmd-dwim-action "cmd-dwim in dir")
+   ("g" counsel-find-file--magit-status-action "magit-status in dir")
+   ("xe" counsel-find-file--eshell-action "eshell in dir")
+   ("ss" counsel-find-file--counsel-ag-action "ag in dir")
+   ("sr" counsel-find-file--counsel-rg-action "rg in dir")))
+
 (defun counsel-projectile-switch-project--jw-sbt-action (project)
   (let ((projectile-switch-project-action 'jw-sbt))
     (counsel-projectile-switch-project-by-name project)))

--- a/emacs.org
+++ b/emacs.org
@@ -1555,6 +1555,8 @@ counsel-keys
 | Key     | Function                  | Scope                 | Hook             | Notes |
 |---------+---------------------------+-----------------------+------------------+-------|
 | M-x     | counsel-M-x               |                       |                  |       |
+| C-o     | ivy-dispatching-done      | ivy-minibuffer-map    |                  |       |
+| M-o     | ivy-dispatching-done-ivy  | ivy-minibuffer-map    |                  |       |
 | C-x C-f | counsel-find-file         |                       |                  |       |
 | C-x F   | counsel-file-jump         |                       |                  |       |
 | C-x b   | counsel-switch-buffer     |                       |                  |       |
@@ -1580,6 +1582,11 @@ counsel-keys
 (setq ivy-use-virtual-buffers t)
 (setq ivy-count-format "%d/%d ")
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
+
+(defun ivy-dispatching-done-ivy ()
+  (interactive)
+  (let ((ivy-read-action-function #'ivy-read-action-ivy))
+    (ivy-dispatching-done)))
 
 (keybinding-org-table 'counsel-keys)
 

--- a/emacs.org
+++ b/emacs.org
@@ -1624,10 +1624,6 @@ counsel-keys
    ("scc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
 #+END_SRC
 
-#+RESULTS:
-| ivy-switch-buffer | ((f ivy--find-file-action find file) (j ivy--switch-buffer-other-window-action other window) (k ivy--kill-buffer-action kill) (r ivy--rename-buffer-action rename) (x counsel-open-buffer-file-externally open externally)) | t | ((i ivy--action-insert insert) (w ivy--action-copy copy)) | swiper-isearch | ((w swiper-action-copy copy)) | swiper | ((w swiper-action-copy copy)) | counsel-describe-variable | ((I counsel-info-lookup-symbol info) (d counsel--find-symbol definition)) | counsel-describe-function | ((I counsel-info-lookup-symbol info) (d counsel--find-symbol definition)) | counsel-describe-symbol | ((I counsel-info-lookup-symbol info) (d counsel--find-symbol definition)) | counsel-M-x | ((d counsel--find-symbol definition) (h #[257 \301!!\207 [counsel-describe-function-function intern] 4 |
-
-
 * private
 
 load the =private= directory and the =private.org= file if they exist

--- a/emacs.org
+++ b/emacs.org
@@ -832,10 +832,6 @@ If the prefix arg is 4, then kill the comment on the current line."
 (defun display-current-prefix-arg (arg)
   (interactive "P")
   (message "%s" arg))
-
-(defun delete-process-i(p)
-  (interactive `(,(completing-read "Kill process: " (mapcar 'process-name (process-list)) () t)))
-  (delete-process p))
 #+END_SRC
 
 *** emacs
@@ -893,7 +889,6 @@ base-keys (keys not in other parts of this config)
 | C-x C-c       | life-might-be-too-much                    |                |      |                           |
 | C-h           | nil                                       |                |      | remove original help      |
 | C-M-?         | help-command                              |                |      |                           |
-| C-M-? p       | delete-process-i                          |                |      |                           |
 | <return>      | toggle-frame-maximized                    | ctl-x-5-map    |      |                           |
 | S-<return>    | toggle-frame-fullscreen                   | ctl-x-5-map    |      |                           |
 | M-!           | cmd-dwim                                  |                |      |                           |
@@ -1570,6 +1565,7 @@ counsel-keys
 | C-M-? f | counsel-describe-function |                       |                  |       |
 | C-M-? v | counsel-describe-variable |                       |                  |       |
 | C-M-? l | counsel-find-library      |                       |                  |       |
+| C-M-? p | counsel-list-processes    |                       |                  |       |
 | M-p     | counsel-esh-history       | eshell-mode-map       | eshell-mode-hook |       |
 | C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
 

--- a/emacs.org
+++ b/emacs.org
@@ -39,10 +39,6 @@ Now, start emacs.
             (defalias 's-nonempty? 's-present?)
             (defalias 's-nonempty-or-nil 's-presence)))
 
-(use-package scratch :pin melpa
-  :config (progn
-            (defalias 'tmp-scratch-buffer 'scratch)))
-
 (use-package org-pomodoro)
 
 (use-package magit)
@@ -931,7 +927,6 @@ base-keys (keys not in other parts of this config)
 | q             | emacs-configs-toggle                      | jw-keymap      |      |                           |
 | d             | date                                      | jw-keymap      |      |                           |
 | i             | toggle-scratch-buffer                     | jw-keymap      |      |                           |
-| I             | tmp-scratch-buffer                        | jw-keymap      |      |                           |
 | C-x C-q       | wdired-change-to-wdired-mode              | dired-mode-map |      |                           |
 | w             | wdired-change-to-wdired-mode              | dired-mode-map |      |                           |
 

--- a/emacs.org
+++ b/emacs.org
@@ -938,6 +938,7 @@ base-keys (keys not in other parts of this config)
 | d             | date                                      | jw-keymap   |      |                           |
 | i             | toggle-scratch-buffer                     | jw-keymap   |      |                           |
 | I             | tmp-scratch-buffer                        | jw-keymap   |      |                           |
+| w             | browse-url-at-point                       | jw-keymap   |      |                           |
 
 #+HEADER: :var base-keys=base-keys
 #+BEGIN_SRC emacs-lisp

--- a/emacs.org
+++ b/emacs.org
@@ -1576,10 +1576,6 @@ counsel-keys
 
 (setq ivy-use-virtual-buffers t)
 (setq ivy-count-format "%d/%d ")
-;; (setq ivy-use-selectable-prompt t) ;; todojoe -- what does this do?
-
-;; ivy-read-action-function can be switched so that actions are selected by cursor
-;; but then they can no longer be selected by key...
 
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
 
@@ -1592,6 +1588,7 @@ counsel-keys
 (defun counsel-find-file--eshell-action (file) (let ((default-directory ivy--directory)) (eshell)))
 (defun counsel-find-file--counsel-ag-action (file) (counsel-ag nil ivy--directory))
 (defun counsel-find-file--counsel-rg-action (file) (counsel-rg nil ivy--directory))
+(defun counsel-find-file--jw-sbt-action (file) (let ((default-directory ivy--directory)) (jw-sbt)))
 
 (ivy-set-actions
  'counsel-find-file
@@ -1599,7 +1596,8 @@ counsel-keys
    ("g" counsel-find-file--magit-status-action "magit-status in dir")
    ("xe" counsel-find-file--eshell-action "eshell in dir")
    ("ss" counsel-find-file--counsel-ag-action "ag in dir")
-   ("sr" counsel-find-file--counsel-rg-action "rg in dir")))
+   ("sr" counsel-find-file--counsel-rg-action "rg in dir")
+   ("js" counsel-find-file--jw-sbt-action "sbt in dir")))
 
 (defun counsel-projectile-switch-project--jw-sbt-action (project)
   (let ((projectile-switch-project-action 'jw-sbt))

--- a/emacs.org
+++ b/emacs.org
@@ -1594,15 +1594,17 @@ counsel-keys
 (defun counsel-find-file--counsel-ag-action (file) (counsel-ag nil ivy--directory))
 (defun counsel-find-file--counsel-rg-action (file) (counsel-rg nil ivy--directory))
 (defun counsel-find-file--jw-sbt-action (file) (let ((default-directory ivy--directory)) (jw-sbt)))
+(defun counsel-find-file--sbt-compile-action (file) (let ((default-directory ivy--directory)) (sbt-compile ivy-current-prefix-arg)))
 
-(ivy-set-actions
+(ivy-add-actions
  'counsel-find-file
- '(("!" counsel-find-file--cmd-dwim-action "cmd-dwim in dir")
-   ("g" counsel-find-file--magit-status-action "magit-status in dir")
-   ("xe" counsel-find-file--eshell-action "eshell in dir")
-   ("ss" counsel-find-file--counsel-ag-action "ag in dir")
-   ("sr" counsel-find-file--counsel-rg-action "rg in dir")
-   ("js" counsel-find-file--jw-sbt-action "sbt in dir")))
+ '(("!" counsel-find-file--cmd-dwim-action "cmd-dwim in pwd")
+   ("g" counsel-find-file--magit-status-action "magit-status in pwd")
+   ("xe" counsel-find-file--eshell-action "eshell in pwd")
+   ("ss" counsel-find-file--counsel-ag-action "ag in pwd")
+   ("sr" counsel-find-file--counsel-rg-action "rg in pwd")
+   ("scs" counsel-find-file--jw-sbt-action "sbt in pwd")
+   ("scc" counsel-find-file--sbt-compile-action "sbt compile in pwd")))
 
 (defun counsel-projectile-switch-project--jw-sbt-action (project)
   (let ((projectile-switch-project-action 'jw-sbt))
@@ -1612,11 +1614,11 @@ counsel-keys
   (let ((projectile-switch-project-action (lambda () (sbt-compile ivy-current-prefix-arg))))
     (counsel-projectile-switch-project-by-name project)))
 
-(ivy-set-actions
+(ivy-add-actions
  'counsel-projectile-switch-project
  '(("g" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky") ;; counsel-projectile defaults magit to v, but I like g
-   ("js" counsel-projectile-switch-project--jw-sbt-action "sbt")
-   ("jc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
+   ("scs" counsel-projectile-switch-project--jw-sbt-action "sbt")
+   ("scc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
 #+END_SRC
 
 * private

--- a/emacs.org
+++ b/emacs.org
@@ -938,7 +938,6 @@ base-keys (keys not in other parts of this config)
 | d             | date                                      | jw-keymap   |      |                           |
 | i             | toggle-scratch-buffer                     | jw-keymap   |      |                           |
 | I             | tmp-scratch-buffer                        | jw-keymap   |      |                           |
-| w             | browse-url-at-point                       | jw-keymap   |      |                           |
 
 #+HEADER: :var base-keys=base-keys
 #+BEGIN_SRC emacs-lisp

--- a/emacs.org
+++ b/emacs.org
@@ -1565,7 +1565,7 @@ counsel-keys
 | C-M-? f | counsel-describe-function |                       |                  |       |
 | C-M-? v | counsel-describe-variable |                       |                  |       |
 | C-M-? l | counsel-find-library      |                       |                  |       |
-| C-M-? p | counsel-list-processes    |                       |                  |       |
+| C-c h p | counsel-list-processes    |                       |                  |       |
 | M-p     | counsel-esh-history       | eshell-mode-map       | eshell-mode-hook |       |
 | C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
 
@@ -1577,13 +1577,6 @@ counsel-keys
 (setq ivy-count-format "%d/%d ")
 (setq ivy-initial-inputs-alist nil)
 (setq max-mini-window-height 0.90) ;; fix for https://github.com/abo-abo/swiper/issues/2397
-
-(require 'cl)
-(defun ivy-remove-action (cmd key)
-  (setq ivy--actions-list
-        (plist-put ivy--actions-list cmd
-                   (cl-remove-if (lambda (action) (equal key (car action)))
-                                 (plist-get ivy--actions-list cmd)))))
 
 (defun ivy-dispatching-done-ivy ()
   (interactive)
@@ -1601,18 +1594,16 @@ counsel-keys
 (defun counsel-find-file--jw-sbt-action (file) (let ((default-directory ivy--directory)) (jw-sbt)))
 (defun counsel-find-file--sbt-compile-action (file) (let ((default-directory ivy--directory)) (sbt-compile ivy-current-prefix-arg)))
 
-(ivy-remove-action 'counsel-find-file "x")
-
 (ivy-add-actions
  'counsel-find-file
  '(("!" counsel-find-file--cmd-dwim-action "cmd-dwim in pwd")
    ("D" counsel-find-file--dired-action "dired in pwd")
    ("g" counsel-find-file--magit-status-action "magit-status in pwd")
-   ("xe" counsel-find-file--eshell-action "eshell in pwd")
    ("ss" counsel-find-file--counsel-ag-action "ag in pwd")
    ("sr" counsel-find-file--counsel-rg-action "rg in pwd")
-   ("scs" counsel-find-file--jw-sbt-action "sbt in pwd")
-   ("scc" counsel-find-file--sbt-compile-action "sbt compile in pwd")))
+   ("C-cme" counsel-find-file--eshell-action "eshell in pwd")
+   ("C-css" counsel-find-file--jw-sbt-action "sbt in pwd")
+   ("C-csc" counsel-find-file--sbt-compile-action "sbt compile in pwd")))
 #+END_SRC
 
 ** projectile
@@ -1640,9 +1631,10 @@ projectile-keys
 
 (ivy-add-actions
  'counsel-projectile-switch-project
- '(("g" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky") ;; counsel-projectile defaults magit to v, but I like g
-   ("scs" counsel-projectile-switch-project--jw-sbt-action "sbt")
-   ("scc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
+ '(("g" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky")
+   ("C-cme" counsel-projectile-switch-project-action-run-eshell "invoke eshell from project root")
+   ("C-css" counsel-projectile-switch-project--jw-sbt-action "sbt")
+   ("C-csc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
 
 (defalias 'projectile-empty-garbage 'projectile-cleanup-known-projects)
 (defalias 'projectile-purge-everything 'projectile-clear-known-projects)

--- a/emacs.org
+++ b/emacs.org
@@ -72,15 +72,11 @@ Now, start emacs.
 (use-package yasnippet)
 (use-package yasnippet-snippets)
 
-(use-package helm)
-(use-package helm-ag)
-(use-package helm-projectile)
-(use-package helm-descbinds)
+(use-package counsel :pin melpa) ;; brings in ivy & swiper
+(use-package counsel-projectile :pin melpa)
 
 (use-package wgrep
   :config (setq wgrep-auto-save-buffer t))
-
-(use-package wgrep-helm)
 
 (use-package undo-tree :pin melpa
   :config (global-undo-tree-mode))
@@ -699,12 +695,13 @@ Interactively:
           (t (message (string-trim (shell-command-to-string prepared-cmd)))))
       (cmd prepared-cmd))))
 
-(jw--define-menu cmd-menu 'cmd-menu
-  :actions '("Command menu (C-c m !)"
-             (?! "sh cmd async    M-! (C-u echo area / C-u C-u at point)" cmd-dwim)
-             (?: "elisp evaluate  M-:" helm-eval-expression-with-eldoc)
-             (?* "calc evaluate   M-*" helm-calcul-expression))
-  :max-action-columns 1)
+;; todojoe do i need this?
+;; (jw--define-menu cmd-menu 'cmd-menu
+;;   :actions '("Command menu (C-c m !)"
+;;              (?! "sh cmd async    M-! (C-u echo area / C-u C-u at point)" cmd-dwim)
+;;              (?: "elisp evaluate  M-:" helm-eval-expression-with-eldoc)
+;;              (?* "calc evaluate   M-*" helm-calcul-expression))
+;;   :max-action-columns 1)
 
 (defun transpose-windows (arg)
   (interactive "p")
@@ -893,6 +890,7 @@ base-keys (keys not in other parts of this config)
 | C-x C-c       | life-might-be-too-much                    |             |      |                           |
 | C-h           | nil                                       |             |      | remove original help      |
 | C-M-?         | help-command                              |             |      |                           |
+| C-M-? p       | list-processes                            |             |      |                           |
 | <return>      | toggle-frame-maximized                    | ctl-x-5-map |      |                           |
 | S-<return>    | toggle-frame-fullscreen                   | ctl-x-5-map |      |                           |
 | M-!           | cmd-dwim                                  |             |      |                           |
@@ -937,7 +935,6 @@ base-keys (keys not in other parts of this config)
 | d             | date                                      | jw-keymap   |      |                           |
 | i             | toggle-scratch-buffer                     | jw-keymap   |      |                           |
 | I             | tmp-scratch-buffer                        | jw-keymap   |      |                           |
-| C-c p         | projectile-command-map                    |             |      |                           |
 
 #+HEADER: :var base-keys=base-keys
 #+BEGIN_SRC emacs-lisp
@@ -1222,111 +1219,6 @@ example of defining specific functions to connect to various irc servers
 (defun twitch-irc-connect ()
   (interactive)
   (rcirc-connect-dwim "irc.chat.twitch.tv" 6667 "nick" "username" "full name" nil "your password"))
-#+END_SRC
-
-** helm
-
-helm-keys
-#+NAME: helm-keys
-| Key     | Function                        | Scope               | Hook             | Notes                    |
-|---------+---------------------------------+---------------------+------------------+--------------------------|
-| C-c h   | helm-command-prefix             |                     |                  |                          |
-| C-x c   | nil                             |                     |                  | undo default helm prefix |
-| M-x     | helm-M-x                        |                     |                  |                          |
-| M-:     | helm-eval-expression-with-eldoc |                     |                  |                          |
-| M-*     | helm-calcul-expression          |                     |                  |                          |
-| C-x C-b | helm-buffers-list               |                     |                  |                          |
-| C-x C-f | helm-find-files                 |                     |                  |                          |
-| M-y     | helm-show-kill-ring             |                     |                  |                          |
-| M-s s   | helm-do-grep-ag                 |                     |                  |                          |
-| M-s o   | helm-occur                      |                     |                  |                          |
-| M-s i   | helm-semantic-or-imenu          |                     |                  |                          |
-| C-x r l | helm-bookmarks                  |                     |                  |                          |
-| C-x r j | helm-register-jump-dwim         |                     |                  |                          |
-| C-h a   | helm-apropos                    |                     |                  |                          |
-| C-h b   | helm-descbinds                  |                     |                  |                          |
-| C-h r   | helm-info-emacs                 |                     |                  |                          |
-| C-h d   | helm-info-at-point              |                     |                  |                          |
-| C-h i   | helm-info                       |                     |                  |                          |
-| h       | helm-descbinds                  | helm-command-map    |                  |                          |
-| M-s s   | helm-ff-run-grep-ag             | helm-find-files-map |                  |                          |
-| C-s     | helm-ff-run-grep-ag             | helm-find-files-map |                  | ag instead of grep       |
-| <tab>   | helm-esh-pcomplete              | eshell-mode-map     | eshell-mode-hook |                          |
-| M-p     | helm-eshell-history             | eshell-mode-map     | eshell-mode-hook |                          |
-
-#+HEADER: :var helm-keys=helm-keys
-#+BEGIN_SRC emacs-lisp
-(require 'helm)
-(require 'helm-config)
-(require 'helm-dabbrev)
-
-(setq helm-split-window-in-side-p t
-      helm-ff-search-library-in-sexp t
-      helm-scroll-amount 8
-      helm-buffer-max-length nil
-      helm-ff-file-name-history-use-recentf t
-      helm-quick-update t
-      helm-move-to-line-cycle-in-source nil
-      helm-mode-fuzzy-match t
-      helm-completion-in-region-fuzzy-match t
-      helm-case-fold-search t
-      helm-ag-insert-at-point 'symbol
-      helm-show-completion-display-function nil ;; do not use separate window for completion selection
-      helm-ff-keep-cached-candidates nil
-      )
-
-(when (eq system-type 'darwin)
-  (setq helm-man-format-switches "%s"))
-
-(defalias 'kill-ring-show 'helm-show-kill-ring)
-(defalias 'list-colors-display 'helm-colors)
-(defalias 'proced 'helm-top)
-
-(defun helm-register-jump-dwim (arg)
-  (interactive "P")
-  (if arg (helm-register) (call-interactively 'jump-to-register)))
-
-(set-face-attribute 'helm-source-header nil :height 1.0 :weight 'normal :family (jw--font-name) :box '(:style released-button))
-(set-face-attribute 'helm-candidate-number nil :background jw--mode-line-color :foreground "goldenrod")
-
-(keybinding-org-table 'helm-keys)
-
-(helm-mode 1)
-(helm-autoresize-mode 1)
-
-(projectile-global-mode)
-(helm-projectile-on)
-
-(setq projectile-completion-system 'helm
-      projectile-mode-line ""  ;; this slowed tramp down sometimes
-      projectile-switch-project-action 'helm-projectile)
-
-(when (executable-find "ag")
-  (setq helm-grep-ag-command "ag -i --nogroup --nocolor --line-numbers %s %s %s")
-  (setq helm-ag-base-command "ag -i --nogroup --nocolor --line-numbers"))
-
-(defun helm-projectile-projects-helm-projectile-ag (dir)
-  (interactive)
-  (with-temp-buffer
-    (let ((default-directory dir))
-      (call-interactively 'helm-projectile-ag))))
-
-(helm-add-action-to-source "Ag in project `M-s a'" 'helm-projectile-projects-helm-projectile-ag helm-source-projectile-projects)
-(helm-projectile-define-key helm-projectile-projects-map (kbd "M-s s") 'helm-projectile-projects-helm-projectile-ag)
-(helm-projectile-define-key helm-projectile-projects-map (kbd "C-s") 'helm-projectile-projects-helm-projectile-ag) ;; hijack grep's keybinding
-
-(defalias 'projectile-empty-garbage 'projectile-cleanup-known-projects)
-(defalias 'projectile-purge-everything 'projectile-clear-known-projects)
-
-(defun projectile-clear-known-projects--advice--ask-y-or-n (original-function)
-  (if (yes-or-no-p "This will REMOVE ALL projects from projectile. Are you sure?")
-      (apply original-function)
-    (message "Did NOT clear the projectile projects.")))
-
-(advice-add 'projectile-clear-known-projects :around 'projectile-clear-known-projects--advice--ask-y-or-n)
-
-(add-to-list 'helm-dabbrev-major-mode-assoc '(scala-mode . sbt-mode))
-
 #+END_SRC
 
 ** org
@@ -1652,27 +1544,54 @@ support ammonite repl in org babel, requires `amm` command, or ammonite-repl
 (org-babel-src-yasnippet 'scala 'ammonite) ;; default ob-scala requires brew scala & ensime, which I don't use.
 #+END_SRC
 
-adding sbt shortcut to helm projectile
+** ivy counsel
+
+counsel-keys
+#+NAME: counsel-keys
+| Key     | Function                  | Scope                 | Hook             | Notes |
+|---------+---------------------------+-----------------------+------------------+-------|
+| M-x     | counsel-M-x               |                       |                  |       |
+| C-x C-f | counsel-find-file         |                       |                  |       |
+| C-x b   | counsel-switch-buffer     |                       |                  |       |
+| M-s o   | swiper-thing-at-point     |                       |                  |       |
+| M-s s   | counsel-ag                |                       |                  |       |
+| M-y     | counsel-yank-pop          |                       |                  |       |
+| C-M-? b | counsel-descbinds         |                       |                  |       |
+| C-M-? f | counsel-describe-function |                       |                  |       |
+| C-M-? v | counsel-describe-variable |                       |                  |       |
+| C-M-? l | counsel-find-library      |                       |                  |       |
+| M-p     | counsel-esh-history       | eshell-mode-map       | eshell-mode-hook |       |
+| C-l     | counsel-up-directory      | counsel-find-file-map |                  |       |
+| C-c p   | projectile-command-map    |                       |                  |       |
+
+#+HEADER: :var counsel-keys=counsel-keys
 #+BEGIN_SRC emacs-lisp
-(require 'helm-projectile)
+(ivy-mode 1)
 
-;; sbt mode uses some local variables which causes issues from inside of the helm and switching between multiple projects
-;; e.g. `sbt:buffer-project-root'
-;; using with-temp-buffer to avoid that
+(setq ivy-use-virtual-buffers t)
+(setq ivy-count-format "")
+;; (setq ivy-use-selectable-prompt t) ;; todojoe -- what does this do?
 
-(defun helm-projectile-projects-sbt (dir)
-  (interactive)
-  (with-temp-buffer
-    (let ((default-directory dir)) (call-interactively 'jw-sbt))))
+(counsel-projectile-mode)
 
-(defun helm-projectile-projects-sbt-compile (dir)
-  (interactive)
-  (with-temp-buffer (let ((default-directory dir)) (call-interactively 'sbt-compile))))
+(keybinding-org-table 'counsel-keys)
 
-(helm-add-action-to-source "Dispatch sbt `C-c s ...'" 'helm-projectile-projects-sbt helm-source-projectile-projects)
+(defun counsel-projectile-switch-project--jw-sbt-action (project)
+  (let ((projectile-switch-project-action 'jw-sbt))
+    (counsel-projectile-switch-project-by-name project)))
 
-(helm-projectile-define-key helm-projectile-projects-map (kbd "C-c s s") 'helm-projectile-projects-sbt)
-(helm-projectile-define-key helm-projectile-projects-map (kbd "C-c s c") 'helm-projectile-projects-sbt-compile)
+(defun counsel-projectile-switch-project--sbt-compile-action (project)
+  (let ((projectile-switch-project-action (lambda () (sbt-compile ivy-current-prefix-arg))))
+    (counsel-projectile-switch-project-by-name project)))
+
+(ivy-set-actions
+ 'counsel-projectile-switch-project
+ '(("g" counsel-projectile-switch-project-action-vc "open project in vc-dir / magit / monky") ;; counsel-projectile defaults magit to v, but I like g
+   ("js" counsel-projectile-switch-project--jw-sbt-action "sbt")
+   ("jc" counsel-projectile-switch-project--sbt-compile-action "sbt compile")))
+
+;; todojoe -- wgrep'ing
+;; todojoe -- how to show more key hints from hydra in M-o?
 #+END_SRC
 
 * private


### PR DESCRIPTION
Changes from helm to ivy:

- This PR adds a `C-l` keybinding to `counsel-find-file` so `C-j` and `C-l` still navigate up/down directories like helm.
- From counsel dispatch menu, use `M-o` to run non-default actions on entry
  - helm allows separate keybindings (or the TAB menu) to perform non-default actions directly from the helm dispatch menu
  - counsel requires `M-o`, e.g. `C-x C-f M-o m` to rename a highlighted file
- To cycle through entries from a previous ivy session in a counsel menu: `M-p` and `M-n`
  - e.g. `counsel-M-x M-p` will go back to the most recently invoked function
- To manually insert thing-at-point into counsel-grep/ag/rg, counsel-find-file, or any counsel menu, use `M-n` (without being on a recent entry via `M-p`)
  - counsel-find-file does not automatically open urls like helm-find-files
  - but inserting a url using `M-n` will open a url at point in browser
    - e.g. `C-x C-f M-n` will open a url
- From any counsel dispatch menu, `ivy-occur` can be opened with `C-c C-o`
  - counsel doesn't have a custom `ag-edit` feature similar to `helm-ag-edit`, just use wgrep.
  - For grep/ag/rg/swiper search sessions, `C-c C-o` opens this buffer and can be wgrep'd using `w` or `C-x C-q`
- This PR adds shortcuts to run counsel-grep/ag/rg, magit, sbt, and shell commands from counsel-find-file or counsel-projectile, via ivy-actions.

WARNING: This PR may or may not swap `M-o` into `C-o` and provide my own custom variation of `M-o` (`ivy-dispatching-done` and `ivy-dispatching-done-ivy`).